### PR TITLE
Ensure compatibility with STM32duino

### DIFF
--- a/src/ShiftedLCD.cpp
+++ b/src/ShiftedLCD.cpp
@@ -42,17 +42,6 @@ void LiquidCrystal::initSPI(uint8_t ssPin) //SPI ###############################
 		
 	SPI.begin(); 
 	
-	//set clockDivider to SPI_CLOCK_DIV2 by default which is 8MHz
-	_clockDivider = SPI_CLOCK_DIV2;
-	SPI.setClockDivider(_clockDivider);
-	
-	//set data mode to SPI_MODE0 by default
-	_dataMode = SPI_MODE0;
-	SPI.setDataMode(_dataMode);
-	
-	//set bitOrder to MSBFIRST by default
-	_bitOrder = MSBFIRST; 
-	SPI.setBitOrder(_bitOrder);
 }
 
 void LiquidCrystal::begin(uint8_t cols, uint8_t lines, uint8_t dotsize) {
@@ -270,13 +259,9 @@ void LiquidCrystal::write4bits(uint8_t value) {
 
 void LiquidCrystal::spiSendOut() //SPI #############################
 {
-  //just in case you are using SPI for more then one device
-  //set bitOrder, clockDivider and dataMode each time
-  SPI.setClockDivider(_clockDivider); 
-  SPI.setBitOrder(_bitOrder);
-  SPI.setDataMode(_dataMode); 
-  
   digitalWrite(_latchPin, LOW);
+  SPI.beginTransaction(SPISettings(8000000, MSBFIRST, SPI_MODE0));
   SPI.transfer(_bitString);
+  SPI.endTransaction();
   digitalWrite(_latchPin, HIGH); 
 }

--- a/src/ShiftedLCD.h
+++ b/src/ShiftedLCD.h
@@ -82,9 +82,6 @@ private:
   //SPI #####################################################################
   uint8_t _bitString; //for SPI  bit0=not used, bit1=RS, bit2=RW, bit3=Enable, bits4-7 = DB4-7
   uint8_t _latchPin;
-  uint8_t _clockDivider;
-  uint8_t _dataMode;
-  uint8_t _bitOrder;//SPI ####################################################
   
   uint8_t _displayfunction;
   uint8_t _displaycontrol;


### PR DESCRIPTION
Use SPISettings instead of calling setClockDivider, setBitOrder, and setDataMode.
This is required for compatibility with STM32 because on that architecture,
bit order is an enum (and not an uint8). This version also remains compatible
with standard Arduino MCUs.