### PR TITLE
Updating the latch pin to follow the schematic example

### DIFF
--- a/examples/HelloWorld_SPI/HelloWorld_SPI.ino
+++ b/examples/HelloWorld_SPI/HelloWorld_SPI.ino
@@ -36,7 +36,7 @@
 
 // initialize the library with the number of the sspin 
 // (or the latch pin of the 74HC595)
-LiquidCrystal lcd(8);
+LiquidCrystal lcd(9);
 
 void setup() {
   // set up the LCD's number of columns and rows: 


### PR DESCRIPTION
In order to use the schematic provided in the README.md, the latch pin must be changed to number 9. Else, data is not sent to the correct pin and the display will not work.